### PR TITLE
Add timeout wrapper for rename test

### DIFF
--- a/tests/test-loop-rename-noportmap.py
+++ b/tests/test-loop-rename-noportmap.py
@@ -1,7 +1,26 @@
 import time
-from pprint import pprint 
-from pyNfsClient import (Mount, NFSv3, MNT3_OK, NFS_PROGRAM,
-                         NFS_V3, NFS3_OK, DATA_SYNC)
+import signal
+from contextlib import contextmanager
+from pyNfsClient import (Mount, NFSv3, MNT3_OK, NFS3_OK, DATA_SYNC)
+
+
+class OperationTimeout(Exception):
+    pass
+
+
+@contextmanager
+def timeout(seconds):
+    """Context manager to timeout blocking socket operations."""
+    def _handle(signum, frame):
+        raise OperationTimeout()
+
+    previous = signal.signal(signal.SIGALRM, _handle)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
 
 host = "10.70.10.110"
 mount_path = "/srv/nfs/sharedfarid"
@@ -25,84 +44,112 @@ TIMEOUT=1
 
 mnt_port = 2049
 
-mount = Mount(host=host, auth=auth, port=mnt_port, timeout=TIMEOUT)
-mount.connect()
 
-print("mounting ...")
-mnt_res = mount.mnt(mount_path, auth)
+class NFSWrapper:
+    def __init__(self, host, mount_path, auth, dir_name, mnt_port=2049, nfs_port=2049, timeout=1):
+        self.host = host
+        self.mount_path = mount_path
+        self.auth = auth
+        self.dir_name = dir_name
+        self.mnt_port = mnt_port
+        self.nfs_port = nfs_port
+        self.timeout = timeout
+        self.mount = None
+        self.nfs3 = None
+        self.root_fh = None
+        self.dir_fh = None
+        self.remount()
 
-if mnt_res["status"] == MNT3_OK:
-    root_fh = mnt_res["mountinfo"]["fhandle"]
-    nfs3 = None
-    try:
-        # nfs_port = portmap.getport(NFS_PROGRAM, NFS_V3)
-        nfs_port = 2049 
-        
-        print("connecting ...")
-        nfs3 = NFSv3(host, nfs_port, timeout=TIMEOUT, auth=auth)
-        nfs3.connect()
+    def _disconnect(self):
+        if self.nfs3:
+            try:
+                self.nfs3.disconnect()
+            except Exception:
+                pass
+        if self.mount:
+            try:
+                self.mount.umnt()
+                self.mount.disconnect()
+            except Exception:
+                pass
 
-        print("mkdir ...")
-        # Create the directory (ignore error if already exists)
-        mkdir_res = nfs3.mkdir(root_fh, dir_name, mode=0o777, auth=auth)
-
-        # Even if it fails, attempt lookup
-        print("file lookup ...")
-        dir_lookup = nfs3.lookup(root_fh, dir_name, auth)
-        if dir_lookup["status"] != NFS3_OK:
-            print(f"Directory lookup failed: {dir_lookup['status']}")
+    def remount(self):
+        self._disconnect()
+        self.mount = Mount(host=self.host, auth=self.auth, port=self.mnt_port, timeout=self.timeout)
+        self.mount.connect()
+        mnt_res = self.mount.mnt(self.mount_path, self.auth)
+        if mnt_res["status"] != MNT3_OK:
+            raise Exception(f"Mount failed: {mnt_res['status']}")
+        self.root_fh = mnt_res["mountinfo"]["fhandle"]
+        self.nfs3 = NFSv3(self.host, self.nfs_port, timeout=self.timeout, auth=self.auth)
+        self.nfs3.connect()
+        # make sure directory handle is valid
+        self.execute(lambda: self.nfs3.mkdir(self.root_fh, self.dir_name, mode=0o777, auth=self.auth))
+        lookup = self.execute(lambda: self.nfs3.lookup(self.root_fh, self.dir_name, self.auth))
+        if lookup["status"] != NFS3_OK:
             raise Exception("Cannot find or create target directory")
-        dir_fh = dir_lookup["resok"]["object"]["data"]
+        self.dir_fh = lookup["resok"]["object"]["data"]
 
-        # Create 100 files with specific content
-        for x in range(1, reps + 1):
-            filename = f"file{x}.txt"
-            file_content = f"this is file number {x}"
-            new_filename = f"renamed_file{x}.txt"
+    def execute(self, op):
+        while True:
+            try:
+                with timeout(self.timeout):
+                    return op()
+            except OperationTimeout:
+                print("Operation timed out. Remounting and retrying ...")
+            except Exception as exc:
+                print(f"Operation failed ({exc}). Remounting and retrying ...")
+            self.remount()
 
-            # 1. Create the file
-            print("create ...")
-            create_res = nfs3.create(dir_fh, filename, CREATE_UNCHECKED, auth=auth)
-            if create_res["status"] != NFS3_OK:
-                print(f"Create failed for {filename}: {create_res['status']}")
-                continue
+    def close(self):
+        self._disconnect()
 
-            # 2. Rename the file
-            print("rename ...")
-            rename_res = nfs3.rename(
-                dir_fh, filename,
-                dir_fh, new_filename,
-                auth=auth
-            )
-            if rename_res["status"] != NFS3_OK:
-                print(f"Rename failed for {filename}: {rename_res['status']}")
-                continue
 
-            print("renamed lookup ...")
-            # 3. Lookup the file handle for the new name
-            renamed_lookup = nfs3.lookup(dir_fh, new_filename, auth)
-            if renamed_lookup["status"] != NFS3_OK:
-                print(f"Lookup failed for {new_filename}: {renamed_lookup['status']}")
-                continue
-            file_fh = renamed_lookup["resok"]["object"]["data"]
+def test_logic(client):
+    for x in range(1, reps + 1):
+        filename = f"file{x}.txt"
+        file_content = f"this is file number {x}"
+        new_filename = f"renamed_file{x}.txt"
 
-            print("write ...")
-            # 4. Write to the renamed file
-            write_res = nfs3.write(file_fh, offset=0, count=len(file_content),
-                                content=file_content, stable_how=DATA_SYNC, auth=auth)
-            if write_res["status"] != NFS3_OK:
-                print(f"Write failed for {new_filename}: {write_res['status']}")
+        create_res = yield lambda: client.nfs3.create(client.dir_fh, filename, CREATE_UNCHECKED, auth=auth)
+        if create_res["status"] != NFS3_OK:
+            print(f"Create failed for {filename}: {create_res['status']}")
+            continue
 
-            print("waiting ...")
-            time.sleep(1)
+        rename_res = yield lambda: client.nfs3.rename(client.dir_fh, filename, client.dir_fh, new_filename, auth=auth)
+        if rename_res["status"] != NFS3_OK:
+            print(f"Rename failed for {filename}: {rename_res['status']}")
+            continue
 
+        renamed_lookup = yield lambda: client.nfs3.lookup(client.dir_fh, new_filename, auth)
+        if renamed_lookup["status"] != NFS3_OK:
+            print(f"Lookup failed for {new_filename}: {renamed_lookup['status']}")
+            continue
+        file_fh = renamed_lookup["resok"]["object"]["data"]
+
+        write_res = yield lambda: client.nfs3.write(file_fh, offset=0, count=len(file_content),
+                                                   content=file_content, stable_how=DATA_SYNC, auth=auth)
+        if write_res["status"] != NFS3_OK:
+            print(f"Write failed for {new_filename}: {write_res['status']}")
+
+        print("waiting ...")
+        time.sleep(1)
+
+
+def run(client, logic):
+    gen = logic(client)
+    result = None
+    while True:
+        try:
+            op = gen.send(result)
+        except StopIteration:
+            break
+        result = client.execute(op)
+
+
+if __name__ == "__main__":
+    client = NFSWrapper(host, mount_path, auth, dir_name, mnt_port=mnt_port, nfs_port=2049, timeout=TIMEOUT)
+    try:
+        run(client, test_logic)
     finally:
-        if nfs3:
-            nfs3.disconnect()
-        mount.umnt()
-        mount.disconnect()
-        # portmap.disconnect()
-else:
-    print(f"Mount failed: {mnt_res['status']}")
-    mount.disconnect()
-    # portmap.disconnect()
+        client.close()


### PR DESCRIPTION
## Summary
- add timeout context manager
- create `NFSWrapper` class to remount on timeout
- run NFS operations through wrapper-driven generator

## Testing
- `python -m py_compile tests/test-loop-rename-noportmap.py`

------
https://chatgpt.com/codex/tasks/task_e_685425bdf22483339c424035fc2dddf3