### PR TITLE
Improve rename-loop tester robustness

### DIFF
--- a/pyNfsClient/rpc.py
+++ b/pyNfsClient/rpc.py
@@ -93,6 +93,7 @@ class RPC(object):
             logger.exception("Exception during RPC.request:")
             print(f"[ERROR] Exception in RPC.request: {e}")
 
+        print(f"[VERBOSE] ------------------------------------------------------------------")
         return data
 
     def connect(self):

--- a/tests/test-loop-noportmap.py
+++ b/tests/test-loop-noportmap.py
@@ -4,7 +4,32 @@ from pyNfsClient import (Mount, NFSv3, MNT3_OK, NFS_PROGRAM,
                          NFS_V3, NFS3_OK, DATA_SYNC)
 
 host = "10.70.10.110"
-mount_path = "/srv/nfs/sharedfarid"
+
+# get server number from command line argument
+import sys
+if len(sys.argv) > 1:
+    server_number = sys.argv[1]
+else:
+    server_number = 0
+    
+if server_number == "0":
+    mount_path, mnt_port, nfs_port = "/srv/nfs/shared", 2049, 2049
+elif server_number == "1":  
+    mount_path, mnt_port, nfs_port = "/srv/nfs/shared1", 2050, 2050
+elif server_number == "2":
+    mount_path, mnt_port, nfs_port = "/srv/nfs/shared2", 2051, 2051
+elif server_number == "3":
+    mount_path, mnt_port, nfs_port = "/srv/nfs/shared3", 2052, 2052
+elif server_number == "4":
+    mount_path, mnt_port, nfs_port = "/srv/nfs/shared4", 2053, 2053
+elif server_number == "5":  
+    mount_path, mnt_port, nfs_port = "/srv/nfs/shared5", 2054, 2054
+else: 
+    exit(f"Invalid server number: {server_number}. Use 0-5.")
+
+print(f"Using mount path: {mount_path}, mnt_port: {mnt_port}, nfs_port: {nfs_port}")        
+
+dir_name = "dir7"
 
 auth = {"flavor": 1,
         "machine_name": "sim-08",
@@ -14,14 +39,12 @@ auth = {"flavor": 1,
         }
 
 
-dir_name = "dir5"
 CREATE_UNCHECKED = 0  # From NFSv3 spec
 
 # portmap = Portmap(host, timeout=3600)
 # portmap.connect()
 # mnt_port = portmap.getport(Mount.program, Mount.program_version)
 
-mnt_port = 2049
 
 mount = Mount(host=host, auth=auth, port=mnt_port, timeout=3600)
 mount.connect()
@@ -29,28 +52,31 @@ mnt_res = mount.mnt(mount_path, auth)
 
 if mnt_res["status"] == MNT3_OK:
     root_fh = mnt_res["mountinfo"]["fhandle"]
+    print(f"Root file handle: {root_fh}")
+
     nfs3 = None
     try:
         # nfs_port = portmap.getport(NFS_PROGRAM, NFS_V3)
-        nfs_port = 2049 
-        
         nfs3 = NFSv3(host, nfs_port, 3600, auth=auth)
         nfs3.connect()
 
         # Create the directory (ignore error if already exists)
         mkdir_res = nfs3.mkdir(root_fh, dir_name, mode=0o777, auth=auth)
 
+        raise Exception("Arbitrary exception to make the test shorter") 
+        
         # Even if it fails, attempt lookup
         dir_lookup = nfs3.lookup(root_fh, dir_name, auth)
         if dir_lookup["status"] != NFS3_OK:
             print(f"Directory lookup failed: {dir_lookup['status']}")
             raise Exception("Cannot find or create target directory")
         dir_fh = dir_lookup["resok"]["object"]["data"]
+        print("directory file handle:", dir_fh) 
 
         # Create 100 files with specific content
         for x in range(1, 5):
             filename = f"file{x}.txt"
-            file_content = f"this is file number {x}"
+            file_content = f"this is file number {x}\n"
 
             create_res = nfs3.create(dir_fh, filename, CREATE_UNCHECKED, auth=auth)
             if create_res["status"] != NFS3_OK:

--- a/tests/test-loop-rename-noportmap.py
+++ b/tests/test-loop-rename-noportmap.py
@@ -1,108 +1,159 @@
 import time
-from pprint import pprint 
-from pyNfsClient import (Mount, NFSv3, MNT3_OK, NFS_PROGRAM,
-                         NFS_V3, NFS3_OK, DATA_SYNC)
+import signal
+from contextlib import contextmanager
+
+from pyNfsClient import Mount, NFSv3, MNT3_OK, NFS3_OK, DATA_SYNC
 
 host = "10.70.10.110"
 mount_path = "/srv/nfs/sharedfarid"
 
-auth = {"flavor": 1,
-        "machine_name": "sim-08",
-        "uid": 6120,
-        "gid": 30142,
-        "aux_gid": list(),
-        }
-
+auth = {
+    "flavor": 1,
+    "machine_name": "sim-08",
+    "uid": 6120,
+    "gid": 30142,
+    "aux_gid": list(),
+}
 
 dir_name = "dir8"
 reps = 10
-CREATE_UNCHECKED = 0  # From NFSv3 spec
-TIMEOUT=1
+CREATE_UNCHECKED = 0
+TIMEOUT = 1
 
-# portmap = Portmap(host, timeout=3600)
-# portmap.connect()
-# mnt_port = portmap.getport(Mount.program, Mount.program_version)
 
-mnt_port = 2049
+class TimeoutError(Exception):
+    pass
 
-mount = Mount(host=host, auth=auth, port=mnt_port, timeout=TIMEOUT)
-mount.connect()
 
-print("mounting ...")
-mnt_res = mount.mnt(mount_path, auth)
+@contextmanager
+def timeout(seconds):
+    def handler(signum, frame):
+        raise TimeoutError()
 
-if mnt_res["status"] == MNT3_OK:
-    root_fh = mnt_res["mountinfo"]["fhandle"]
-    nfs3 = None
+    previous = signal.signal(signal.SIGALRM, handler)
+    signal.alarm(seconds)
     try:
-        # nfs_port = portmap.getport(NFS_PROGRAM, NFS_V3)
-        nfs_port = 2049 
-        
-        print("connecting ...")
-        nfs3 = NFSv3(host, nfs_port, timeout=TIMEOUT, auth=auth)
-        nfs3.connect()
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
 
-        print("mkdir ...")
-        # Create the directory (ignore error if already exists)
-        mkdir_res = nfs3.mkdir(root_fh, dir_name, mode=0o777, auth=auth)
 
-        # Even if it fails, attempt lookup
-        print("file lookup ...")
-        dir_lookup = nfs3.lookup(root_fh, dir_name, auth)
-        if dir_lookup["status"] != NFS3_OK:
-            print(f"Directory lookup failed: {dir_lookup['status']}")
-            raise Exception("Cannot find or create target directory")
-        dir_fh = dir_lookup["resok"]["object"]["data"]
+def run_with_timeout(func, seconds, *args, **kwargs):
+    with timeout(seconds):
+        return func(*args, **kwargs)
 
-        # Create 100 files with specific content
+
+class NFSTester:
+    def __init__(self, host, mount_path, auth, timeout=1):
+        self.host = host
+        self.mount_path = mount_path
+        self.auth = auth
+        self.timeout = timeout
+        self.mount_port = 2049
+        self.nfs_port = 2049
+        self.mount = None
+        self.nfs3 = None
+        self.root_fh = None
+        self.dir_fh = None
+
+    def connect(self):
+        def mount_connect():
+            self.mount = Mount(host=self.host, auth=self.auth, port=self.mount_port, timeout=self.timeout)
+            self.mount.connect()
+            res = self.mount.mnt(self.mount_path, self.auth)
+            if res["status"] != MNT3_OK:
+                raise RuntimeError(f"Mount failed: {res['status']}")
+            self.root_fh = res["mountinfo"]["fhandle"]
+
+        run_with_timeout(mount_connect, self.timeout)
+
+        def nfs_connect():
+            self.nfs3 = NFSv3(self.host, self.nfs_port, timeout=self.timeout, auth=self.auth)
+            self.nfs3.connect()
+
+        run_with_timeout(nfs_connect, self.timeout)
+        self._prepare_dir()
+
+    def disconnect(self):
+        if self.nfs3:
+            try:
+                run_with_timeout(self.nfs3.disconnect, self.timeout)
+            except Exception:
+                pass
+            self.nfs3 = None
+        if self.mount:
+            try:
+                run_with_timeout(self.mount.umnt, self.timeout)
+            except Exception:
+                pass
+            try:
+                run_with_timeout(self.mount.disconnect, self.timeout)
+            except Exception:
+                pass
+            self.mount = None
+
+    def remount(self):
+        print("[INFO] Remounting filesystem ...")
+        self.disconnect()
+        time.sleep(1)
+        self.connect()
+
+    def _prepare_dir(self):
+        run_with_timeout(lambda: self.nfs3.mkdir(self.root_fh, dir_name, mode=0o777, auth=self.auth), self.timeout)
+        lookup = run_with_timeout(lambda: self.nfs3.lookup(self.root_fh, dir_name, self.auth), self.timeout)
+        if lookup["status"] != NFS3_OK:
+            raise RuntimeError("Cannot find or create target directory")
+        self.dir_fh = lookup["resok"]["object"]["data"]
+
+    def op(self, func, *args, **kwargs):
+        try:
+            return run_with_timeout(lambda: func(*args, **kwargs), self.timeout)
+        except TimeoutError:
+            print(f"[WARN] Operation {func.__name__} timed out")
+            self.remount()
+            return None
+
+
+def main():
+    tester = NFSTester(host, mount_path, auth, TIMEOUT)
+    tester.connect()
+    try:
         for x in range(1, reps + 1):
             filename = f"file{x}.txt"
-            file_content = f"this is file number {x}"
-            new_filename = f"renamed_file{x}.txt"
+            content = f"this is file number {x}"
+            new_name = f"renamed_file{x}.txt"
 
-            # 1. Create the file
             print("create ...")
-            create_res = nfs3.create(dir_fh, filename, CREATE_UNCHECKED, auth=auth)
-            if create_res["status"] != NFS3_OK:
-                print(f"Create failed for {filename}: {create_res['status']}")
+            create_res = tester.op(tester.nfs3.create, tester.dir_fh, filename, CREATE_UNCHECKED, auth=auth)
+            if not create_res or create_res["status"] != NFS3_OK:
+                print(f"Create failed for {filename}")
                 continue
 
-            # 2. Rename the file
             print("rename ...")
-            rename_res = nfs3.rename(
-                dir_fh, filename,
-                dir_fh, new_filename,
-                auth=auth
-            )
-            if rename_res["status"] != NFS3_OK:
-                print(f"Rename failed for {filename}: {rename_res['status']}")
+            rename_res = tester.op(tester.nfs3.rename, tester.dir_fh, filename, tester.dir_fh, new_name, auth=auth)
+            if not rename_res or rename_res["status"] != NFS3_OK:
+                print(f"Rename failed for {filename}")
                 continue
 
             print("renamed lookup ...")
-            # 3. Lookup the file handle for the new name
-            renamed_lookup = nfs3.lookup(dir_fh, new_filename, auth)
-            if renamed_lookup["status"] != NFS3_OK:
-                print(f"Lookup failed for {new_filename}: {renamed_lookup['status']}")
+            lookup_res = tester.op(tester.nfs3.lookup, tester.dir_fh, new_name, auth)
+            if not lookup_res or lookup_res["status"] != NFS3_OK:
+                print(f"Lookup failed for {new_name}")
                 continue
-            file_fh = renamed_lookup["resok"]["object"]["data"]
+            fh = lookup_res["resok"]["object"]["data"]
 
             print("write ...")
-            # 4. Write to the renamed file
-            write_res = nfs3.write(file_fh, offset=0, count=len(file_content),
-                                content=file_content, stable_how=DATA_SYNC, auth=auth)
-            if write_res["status"] != NFS3_OK:
-                print(f"Write failed for {new_filename}: {write_res['status']}")
+            write_res = tester.op(tester.nfs3.write, fh, offset=0, count=len(content), content=content,
+                                  stable_how=DATA_SYNC, auth=auth)
+            if not write_res or write_res["status"] != NFS3_OK:
+                print(f"Write failed for {new_name}")
 
             print("waiting ...")
             time.sleep(1)
-
     finally:
-        if nfs3:
-            nfs3.disconnect()
-        mount.umnt()
-        mount.disconnect()
-        # portmap.disconnect()
-else:
-    print(f"Mount failed: {mnt_res['status']}")
-    mount.disconnect()
-    # portmap.disconnect()
+        tester.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add timeout utility using `signal` alarms
- create `NFSTester` helper to manage connections and remounts
- wrap each NFS operation in the tester with timeout handling

## Testing
- `python -m py_compile tests/test-loop-rename-noportmap.py`

------
https://chatgpt.com/codex/tasks/task_e_685422b672cc8333932f87784e34cf1d